### PR TITLE
make createTestData script work for frontend

### DIFF
--- a/tests/createTestData.js
+++ b/tests/createTestData.js
@@ -113,7 +113,19 @@ async function createTestData(filename) {
   await Promise.all(
     testdata[filename].data.map((entry) => {
       return promiseHelper(async () => {
-        data[route][entry.id] = await post(route, replacePlaceholders(entry.data), replacePlaceholders(entry.token));
+        const dataObject = replacePlaceholders(entry.data);
+        const tokenObject = replacePlaceholders(entry.token);
+        try {
+          const response = await post(route, dataObject, tokenObject);
+          if (!response) {
+            throw new Error("No data received");
+          }
+          data[route][entry.id] = response;
+        } catch {
+          if (testdata[filename].alternativeRoute) {
+            data[route][entry.id] = await post(testdata[filename].alternativeRoute, dataObject, tokenObject);
+          }
+        }
       });
     })
   );

--- a/tests/testdata/users.js
+++ b/tests/testdata/users.js
@@ -1,5 +1,6 @@
 module.exports = {
   route: 'signup',
+  alternativeRoute: 'login',
   data: [
     {
       id: 'jreichwald',


### PR DESCRIPTION
I updated the createTestData script to work also when server is running on `https://localhost/api`. I only tested it partially with Fabio but the fix needs to be checked as a whole... preferably by someone who can run docker on his machine 😄