### PR TITLE
add unique constraint to name of field of study

### DIFF
--- a/models/fieldOfStudy.js
+++ b/models/fieldOfStudy.js
@@ -11,6 +11,7 @@ module.exports = (sequelize, DataTypes) => {
       name: {
         type: DataTypes.STRING,
         allowNull: false,
+        unique: true,
       },
     },
     {


### PR DESCRIPTION
this partially closes #131

This will prevent the creation of a duplicate item.

**But** it will not stop the creation of `Wirtschaftsinformatik` and `wirtschaftsinformatik` as they are completely different to the database. It should still prevent the users of mistakenly creating the same field of study twice.


EDIT: sorry, added the wrong issue number.