### PR TITLE
Readme header template

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@
     ><img src="https://img.shields.io/badge/build-success-success" alt="build status"
     ></a>
     <a href="https://youtu.be/dQw4w9WgXcQ" title="Manual Test Coverage"
-    ><img src="https://img.shields.io/badge/coverage-93%-success" alt="test coverage: 93%"
+    ><img src="https://img.shields.io/badge/coverage-93%25-success" alt="test coverage: 93%"
     ></a>
     <a href="https://github.com/nikolockenvitz/dhbw-project-backend/blob/master/LICENSE"
     ><img src="https://img.shields.io/badge/license-MIT-success" alt="MIT License"


### PR DESCRIPTION
I suggest to have the same README header for all our peojekt / exoplan repositories.
- logo
- links to other repositories
- [optional] badges, e.g. version, license, build status, ...
- [optional] short description (1-2 sentences/lines)

Feel free to give feedback or adjust it.

I think it may be the easiest to update the README of the other repositories after moving it to [wwi17seb](https://github.com/wwi17seb)